### PR TITLE
Add label for current vote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/settings.json
 package-lock.json
+venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+websockets

--- a/service.py
+++ b/service.py
@@ -72,7 +72,8 @@ async def counter(websocket, path):
         await unregister(websocket)
 
 
-start_server = websockets.serve(counter, "", 6789)
+if __name__ == '__main__':
+    start_server = websockets.serve(counter, "", 6789)
 
-asyncio.get_event_loop().run_until_complete(start_server)
-asyncio.get_event_loop().run_forever()
+    asyncio.get_event_loop().run_until_complete(start_server)
+    asyncio.get_event_loop().run_forever()

--- a/web/index.html
+++ b/web/index.html
@@ -18,7 +18,9 @@
       <input type="range" min="1" max="5" value="4" class="slider enabled">
 
       <input type="checkbox" class="checkbox" id="mute">
+      <br>
       <label for="mute">enthalten</label>
+      <span>Abgestimmt für <b id="currentValue">ok</b></span>
 
       <a href="https://github.com/drogenfrosch2/profbremse">verbessern</a>
     </div>
@@ -29,15 +31,27 @@
         usercount = document.querySelector('.usercount'),
         checkbox = document.querySelector('.checkbox'),
         ctx = document.getElementById('myChart'),
-        host = location.host;
+        currentValue = document.getElementById('currentValue')
+        host = location.host.split(':')[0];
+
 
     var states = [];
     var nbr_user = 1;
+    let labels = ['Bahnhof', 'äääääh', 'äh', 'ok', 'schneller'];
 
     websocket = new WebSocket("ws://"+ host +":6789/");
 
+    function updateValue(value) {
+      websocket.send(JSON.stringify({value: value}));
+      if (value == 0) {
+        currentValue.textContent = 'Enthalten';
+      } else {
+        currentValue.textContent = labels[value - 1];
+      }
+    }
+
     slider.onchange = function (event){
-      websocket.send(JSON.stringify({value: slider.value}));
+      updateValue(slider.value);
     }
 
     websocket.onmessage = function (event) {
@@ -70,22 +84,19 @@
       if(checkbox.checked == true){
         slider.setAttribute('disabled','disabled');
         slider.classList.remove("enabled");
-        websocket.send(JSON.stringify({value: 0}));
+        updateValue(0);
       }
       else{
         slider.removeAttribute('disabled');
         slider.classList.add("enabled");
-        websocket.send(JSON.stringify({value: slider.value}));
+        updateValue(slider.value);
       }
     }
-
-
-
     
     var myChart = new Chart(ctx, {
         type: 'bar',
         data: {
-            labels: ['Bahnhof', 'äääääh', 'äh', 'ok', 'schneller'],
+            labels: labels,
             datasets: [{
                 label: 'Stimmung',
                 data: states,
@@ -118,7 +129,7 @@
                 }]
             }
         }
-      })
+      });
 
   </script>
 


### PR DESCRIPTION
Add a label that displays the current vote.

Also remove the port on `window.location.host` when not using the default port 80. As I use `python -m http.server` for local development, port `8000` is selected by default and included in `host`.